### PR TITLE
made CamomileDefaultConfig visible to users

### DIFF
--- a/Camomile/camomileLibrary.mlip
+++ b/Camomile/camomileLibrary.mlip
@@ -39,7 +39,10 @@
     #include "configInt.mli"
   end
 
-(** Indivisual modules *)
+(** Default configuration. *)
+  module DefaultConfig : ConfigInt.Type
+
+(** Individual modules *)
 
   module OOChannel : sig
     #include "oOChannel.mli"

--- a/Camomile/camomileLibrary.mlp
+++ b/Camomile/camomileLibrary.mlp
@@ -1,5 +1,7 @@
 module ConfigInt = ConfigInt
 
+module DefaultConfig = CamomileDefaultConfig
+
 (** Individual modules *)
 
 module OOChannel = OOChannel


### PR DESCRIPTION
Suppose a user wants to redefine how data files are searched, but would
like to fall back to the paths in CamomileDefaultConfig.  If the user
tries to access those paths thru CamomileLibraryDefault.Config, then
the program will crash if the paths in CamomileDefaultConfig are wrong,
_even if the custom search procedure would otherwise succeed_. This is
because the module CamomileLibraryDefault also evaluates a functor, and
that fails. (Same thing with CamomileLibraryDyn.)
