### PR TITLE
Fix the compilation of camomile.cmxs

### DIFF
--- a/Camomile/Makefile.in
+++ b/Camomile/Makefile.in
@@ -140,7 +140,7 @@ camomile.cma : $(OBJECTS) camomileLibrary.cmo camomileLibraryDefault.cmo camomil
 camomile.cmxa : $(OPTOBJECTS) camomileLibrary.cmx camomileLibraryDefault.cmx camomileLibraryDyn.cmx
 	$(OCAMLOPT) -a -o camomile.cmxa $(OPTOBJECTS) camomileLibrary.cmx camomileLibraryDefault.cmx camomileLibraryDyn.cmx
 camomile.cmxs : camomile.cmxa
-	$(OCAMLOPT) -shared -o camomile.cmxs camomile.cmxa
+	$(OCAMLOPT) -shared -linkall -o camomile.cmxs camomile.cmxa
 
 camomileLibrary.cma : $(OBJECTS) camomileLibrary.cmo
 	$(OCAMLC) -a -o camomileLibrary.cma $(OBJECTS) camomileLibrary.cmo


### PR DESCRIPTION
I'm sorry I didn't tested it very well. Here is the fix.
It ended up with:

```
undefined symbol: camlCamomileLibraryDefault
```

By the way, what's the purpose of camomileLibrary ?
