### PR TITLE
4.05 typing fix

### DIFF
--- a/Camomile/internal/unimap.ml
+++ b/Camomile/internal/unimap.ml
@@ -58,7 +58,7 @@ val of_name : string -> t
 end
 
 
-module Make (Config : ConfigInt.Type) = struct
+module Make (Config : ConfigInt.Type) : Type = struct
 
 type mapping = {no_char : int; tbl : Tbl31.Bytes.t}
 

--- a/Camomile/public/uCharInfo.ml
+++ b/Camomile/public/uCharInfo.ml
@@ -298,7 +298,7 @@ val load_composition_exclusion_tbl : unit -> UCharTbl.Bool.t
 
 end
 
-module Make (Config : ConfigInt.Type) = struct
+module Make (Config : ConfigInt.Type) : Type = struct
 include Unidata.Make(Config)
 
 (* General category *)


### PR DESCRIPTION
In 4.05, checking for non-generalizable inference variable (`'_a`)
(forbidden in toplevel modules and functors) happens before checking
the .ml file against the .mli signature, so non-generalizable
variables that were previously resolved through the .mli constraint
are now underspecified and result in a compilation failure
(see MPR#7414, GPR#929). This commit adds enough annotations to avoid
such underspecified variables in functors.