### PR TITLE
Fix 4.05 typing a second time

### DIFF
--- a/Camomile/internal/unimap.ml
+++ b/Camomile/internal/unimap.ml
@@ -100,7 +100,7 @@ let ucs_to_enc map ucs = read_map map.ucs_to_enc ucs
 
 let loaded = Hashtbl.create 0
 
-let of_name name =
+let of_name name : t =
   try 
     let b = Hashtbl.find loaded name in
     match Weak.get b 0 with

--- a/Camomile/public/uCharInfo.ml
+++ b/Camomile/public/uCharInfo.ml
@@ -566,7 +566,7 @@ type special_casing_property =
 
 let cache = Weak.create 1
 
-let load_conditional_casing_tbl () =
+let load_conditional_casing_tbl () : special_casing_property list UCharTbl.t =
   match Weak.get cache 0 with
     Some t -> t
   | None ->


### PR DESCRIPTION
The build of camomile with ocaml 4.05 branch (with the fixes for the future 4.05.1 release) is again broken. These commits add some additional type annotation similar to @gasche ones. It seems to occur since commit a38350d5c02d021657c18a36b56d79ef669f7054 of ocaml (MR ocaml/ocaml#1272).

Even if it is ocaml fault, the modification of camomile is small.