### PR TITLE
Add support for 4.02.3

### DIFF
--- a/Camomile/internal/unidata.ml
+++ b/Camomile/internal/unidata.ml
@@ -299,6 +299,13 @@ type script_type =
   | `Buhid
   | `Tagbanwa ]
 
+(* little hack to maintain 4.02.3 compat with warnings *)
+module String = struct
+  [@@@ocaml.warning "-3-32"]
+  let lowercase_ascii = StringLabels.lowercase
+  include String
+end
+
 let script_of_name name =
   match String.lowercase_ascii name with
   | "common" -> `Common

--- a/Camomile/tools/parse_specialcasing.ml
+++ b/Camomile/tools/parse_specialcasing.ml
@@ -47,6 +47,13 @@ let us_of_codes codes = List.map uchar_of_code codes
 let not_pat = Str.regexp "not_\\(.*\\)"
 let locale_pat = Str.regexp "\\(..\\)\\(_\\(..\\)\\)?\\(_\\(.+\\)\\)?"
 
+(* little hack to maintain 4.02.3 compat with warnings *)
+module String = struct
+  [@@@ocaml.warning "-3-32"]
+  let lowercase_ascii = StringLabels.lowercase
+  include String
+end
+
 let rec parse_condition condition =
   let s = String.lowercase_ascii condition in
   match s with

--- a/camomile-test/tester/test-caseMap.ml
+++ b/camomile-test/tester/test-caseMap.ml
@@ -7,6 +7,13 @@ open CamomileLibraryTest.Camomile
 
 module UTF8Casing = CaseMap.Make (UTF8)
 
+(* little hack to maintain 4.02.3 compat with warnings *)
+module String = struct
+  [@@@ocaml.warning "-3-32"]
+  let lowercase_ascii = StringLabels.lowercase
+  include String
+end
+
 let _ = random_test
     ~desc:"ASCII"
     ~log:"caseMap_ASCII"

--- a/camomile.opam
+++ b/camomile.opam
@@ -16,3 +16,4 @@ depends: [
   "cppo" {build}
   "base-bytes"
 ]
+available: [ocaml-version >= "4.02.3"]

--- a/jbuild-workspace.dev
+++ b/jbuild-workspace.dev
@@ -1,5 +1,5 @@
 ;; This file is used by `make all-supported-ocaml-versions`
 (context ((switch 4.03.0)))
-(context ((switch 4.04.1)))
-(context ((switch 4.05.0+trunk)))
-(context ((switch 4.06.0+trunk)))
+(context ((switch 4.04.2)))
+(context ((switch 4.05.0)))
+(context ((switch 4.06.0)))

--- a/jbuild-workspace.dev
+++ b/jbuild-workspace.dev
@@ -1,4 +1,5 @@
 ;; This file is used by `make all-supported-ocaml-versions`
+(context ((switch 4.02.3)))
 (context ((switch 4.03.0)))
 (context ((switch 4.04.2)))
 (context ((switch 4.05.0)))


### PR DESCRIPTION
I know @yoriyuki stated that supporting very old versions of OCaml is too costly to maintain, but supporting 4.02.3 turned out to be easy enough with a small series of hacks I made. The reason why I did this is that Camomile is necessary for utop and hence reason which still supports 4.02.3 because of bucklescript. It would be great to restore 4.02.3 compat and make a bugfix release. If in the future, compat with 4.02.3 is broken, then we'll revaluate how hard it would be to support it again. But for now let's make the change a bit more gradual for everyone.

cc @jordwalke