### PR TITLE
Guard all non tail recursive calls behind Stream.slazy

### DIFF
--- a/Camomile/tools/camomilelocaledef_lexer.ml
+++ b/Camomile/tools/camomilelocaledef_lexer.ml
@@ -58,11 +58,12 @@ let rec remove_comment s =
     begin match Stream.next s with
       | Some '/', _, _ -> comment s
       | Some '*', _, _ -> comment2 s
-      | _ -> Stream.icons data (remove_comment s)
-      | exception Stream.Failure -> Stream.icons data (remove_comment s)
+      | _ -> Stream.icons data (Stream.slazy (fun () -> remove_comment s))
+      | exception Stream.Failure ->
+        Stream.icons data (Stream.slazy (fun () -> remove_comment s))
     end
-  | (Some '"', _, _) as data -> Stream.icons data (in_quote s)
-  | data -> Stream.icons data (remove_comment s)
+  | (Some '"', _, _) as data -> Stream.icons data (Stream.slazy (fun () -> in_quote s))
+  | data -> Stream.icons data (Stream.slazy (fun () -> remove_comment s))
   | exception Stream.Failure -> Stream.sempty
 and comment s =
   match Stream.next s with
@@ -85,35 +86,39 @@ and in_quote s =
   | [(Some '\\', _, _) as data1; data2] ->
     Stream.junk s;
     Stream.junk s;
-    Stream.icons data1 (Stream.icons data2 (in_quote s))
+    Stream.icons data1 (Stream.icons data2 (Stream.slazy (fun () -> in_quote s)))
   | [(Some '"', _, _) as data; _]
   | [(Some '"', _, _) as data] ->
     Stream.junk s;
-    Stream.icons data (remove_comment s)
+    Stream.icons data (Stream.slazy (fun () -> remove_comment s))
   | _ ->
     begin match Stream.next s with
-    | data -> Stream.icons data (in_quote s)
+    | data -> Stream.icons data (Stream.slazy (fun () -> in_quote s))
     | exception Stream.Failure -> Stream.sempty
     end
 
 let rec merge_text st =
   match Stream.next st with
   | Text s -> do_merge s st
-  | e -> Stream.icons e (merge_text st)
+  | e -> Stream.icons e (Stream.slazy (fun () -> merge_text st))
   | exception Stream.Failure -> Stream.sempty
 and do_merge s st =
   match Stream.next st with
-  | Text s' -> do_merge (s ^ s') st
-  | e -> Stream.icons (Text s) (Stream.icons e (merge_text st))
-  | exception Stream.Failure -> Stream.sempty
+  | Text s' ->
+    do_merge (s ^ s') st
+  | e ->
+    Stream.icons (Text s)
+      (Stream.icons e (Stream.slazy (fun () -> merge_text st)))
+  | exception Stream.Failure ->
+    Stream.sempty
 
 let lexer s =
   let rec parse s =
       match Stream.next s with
-      | Some '{', _, _ -> Stream.icons Brace_l (parse s)
-      | Some '}', _, _ -> Stream.icons Brace_r (parse s)
-      | Some ':', _, _ -> Stream.icons Colon (parse s)
-      | Some ',', _, _ -> Stream.icons Comma (parse s)
+      | Some '{', _, _ -> Stream.icons Brace_l (Stream.slazy (fun () -> parse s))
+      | Some '}', _, _ -> Stream.icons Brace_r (Stream.slazy (fun () -> parse s))
+      | Some ':', _, _ -> Stream.icons Colon (Stream.slazy (fun () -> parse s))
+      | Some ',', _, _ -> Stream.icons Comma (Stream.slazy (fun () -> parse s))
       | Some '"', _, _ -> quote s
       | Some ('\r' | '\n' | '\133' | '\t'), _, _
       | _, (`Zs | `Zl | `Zp), _ -> parse s
@@ -134,7 +139,7 @@ let lexer s =
         | Some '"', _, _ ->
           let s = Utf8Buffer.contents buf in
           let s' = unescape s in
-          Stream.icons (Text s') (parse st)
+          Stream.icons (Text s') (Stream.slazy (fun () -> parse st))
         | _, _, u ->
           Utf8Buffer.add_char buf u;
           loop st
@@ -149,11 +154,12 @@ let lexer s =
       |  _, (`Zs | `Zl | `Zp), _ ->
         let s = Utf8Buffer.contents buf in
         let s' = unescape s in
-        Stream.icons (Text s') (parse st)
+        Stream.icons (Text s') (Stream.slazy (fun () -> parse st))
       |	(Some ('{' | '}' | ':' | ','| '"'), _, _) as e ->
         let s = Utf8Buffer.contents buf in
         let s' = unescape s in
-        Stream.icons (Text s') (parse (Stream.icons e st))
+        Stream.icons (Text s')
+          (Stream.slazy (fun () -> parse (Stream.icons e st)))
       |	 _, _, u ->
         Utf8Buffer.add_char buf u;
         loop st


### PR DESCRIPTION
This should make the lexer work with a smaller stack.

You can test how well our "low stack mode" works with the following patch:

```
diff --git a/Camomile/tools/jbuild b/Camomile/tools/jbuild
index 7f9d96f..19550cf 100644
--- a/Camomile/tools/jbuild
+++ b/Camomile/tools/jbuild
@@ -16,6 +16,7 @@
 
 (executable
  ((name camomilelocaledef)
+  (modes (byte))
   (libraries (toolslib))
   (flags (-I Camomile :standard))
   (modules (camomilelocaledef camomilelocaledef_lexer))))
```

and by running it with:

```
OCAMLRUNPARAM='b,l=1000' jbuilder build -j1
```

Before this patch, this would fail for me on `ar.mar`. Now it fails on `ja.mar` with a stackoverflow in the parser now:

```
camomilelocaledef Camomile/locales/it_IT_PREEURO.mar
camomilelocaledef Camomile/locales/iw.mar
camomilelocaledef Camomile/locales/iw_IL.mar
camomilelocaledef Camomile/locales/ja.mar (exit 2)
(cd _build/default/Camomile && ./tools/camomilelocaledef.exe --file locales/ja.txt locales)
Warning : strength option is not supported
Fatal error: exception Stack overflow
Raised by primitive operation at file "Camomile/toolslib/colParser.mly", line 157, characters 26-34
Called from file "Camomile/toolslib/colParser.mly", line 157, characters 26-34
Called from file "Camomile/toolslib/colParser.mly", line 157, characters 26-34
Called from file "Camomile/toolslib/colParser.mly", line 157, characters 26-34
...
Called from file "Camomile/toolslib/colParser.mly", line 157, characters 26-34
Called from file "Camomile/toolslib/colParser.mly", line 157, characters 26-34
Called from file "Camomile/toolslib/colParser.mly", line 157, characters 26-34
Called from file "Camomile/toolslib/colParser.mly", line 157, characters 26-34
Called from file "Camomile/toolslib/colParser.mly", line 157, characters 26-34
Called from file "Camomile/toolslib/colParser.mly", line 137, characters 35-41
Called from file "Camomile/toolslib/colParser.mly", line 67, characters 25-42
Called from file "parsing.ml", line 142, characters 39-75
Re-raised at file "parsing.ml", line 145, characters 8-25
Called from file "parsing.ml", line 164, characters 4-28
Re-raised at file "parsing.ml", line 183, characters 14-17
Called from file "Camomile/tools/camomilelocaledef.ml", line 199, characters 17-53
Called from file "Camomile/tools/camomilelocaledef.ml", line 207, characters 20-31
Called from file "Camomile/tools/camomilelocaledef.ml", line 229, characters 22-37
Called from file "hashtbl.ml", line 266, characters 8-18
Called from file "hashtbl.ml", line 272, characters 6-21
Re-raised at file "hashtbl.ml", line 277, characters 10-13
Called from file "Camomile/tools/camomilelocaledef.ml", line 236, characters 8-15
```

I wonder if this is a sign that we should just give up and force camomilelocaledef to run in bytecode mode so that we don't have to worry about the stack space.