### PR TITLE
Remove false bytes dependency

### DIFF
--- a/camomile.opam
+++ b/camomile.opam
@@ -12,6 +12,5 @@ build: [
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "jbuilder" {build & >= "1.0+beta17"}
-  "base-bytes"
 ]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
We don't need this as Camomile is >= 4.02.3 and bytes is already included.