### PR TITLE
Fix old ocaml compat

### DIFF
--- a/Camomile/camomile_do_not_use.ml
+++ b/Camomile/camomile_do_not_use.ml
@@ -1,0 +1,1 @@
+[@@@ocaml.deprecated "this module is an empty. ignore it"]

--- a/Camomile/jbuild
+++ b/Camomile/jbuild
@@ -11,6 +11,7 @@
   (libraries (bigarray camomileDefaultConfig))
   (modules
    (:standard \ camomileDefaultConfig
+    camomile_do_not_use
     installConfig
     camomileLibraryDyn
     camomileLibraryDefault))))
@@ -39,7 +40,7 @@
   (public_name camomile)
   (wrapped false)
   (flags (:standard))
-  (modules ())
+  (modules (camomile_do_not_use))
   (libraries
    (camomile.library
     camomile.default_config

--- a/jbuild-workspace.dev
+++ b/jbuild-workspace.dev
@@ -3,4 +3,4 @@
 (context ((switch 4.03.0)))
 (context ((switch 4.04.2)))
 (context ((switch 4.05.0)))
-(context ((switch 4.06.0)))
+(context ((switch 4.06.1)))


### PR DESCRIPTION
We should probably make a point release and update the constraints of 1.0.0. It should be `>= 4.05.0`