### PR TITLE
Fix parallel build: Delay toplevel database reads

### DIFF
--- a/Camomile/public/uCharInfo.ml
+++ b/Camomile/public/uCharInfo.ml
@@ -229,11 +229,11 @@ module Make (Config : ConfigInt.Type) : Type = struct
 
   (* General category *)
 
-  let general_category_tbl : UCharTbl.Bits.t =
-    read_data "general_category"
+  let general_category_tbl : UCharTbl.Bits.t Lazy.t =
+    lazy (read_data "general_category")
 
   let general_category u =
-    match UCharTbl.Bits.get general_category_tbl u with
+    match UCharTbl.Bits.get (Lazy.force general_category_tbl) u with
       0 ->
       let n = UChar.uint_code u in
       if n >= 0x0f0000 && n <= 0x100000 then `Co else
@@ -404,9 +404,9 @@ module Make (Config : ConfigInt.Type) : Type = struct
 
   (* Scripts *)
 
-  let script_tbl : UCharTbl.Bits.t = read_data "scripts"
+  let script_tbl : UCharTbl.Bits.t Lazy.t = lazy (read_data "scripts")
 
-  let script u = script_of_num (UCharTbl.Bits.get script_tbl u)
+  let script u = script_of_num (UCharTbl.Bits.get (Lazy.force script_tbl) u)
   let load_script_map () = read_data "scripts_map"
 
   type version_type =
@@ -440,9 +440,9 @@ module Make (Config : ConfigInt.Type) : Type = struct
     | `v3_2 -> '\x32'
     | `Nc   -> '\xfe'
 
-  let age_tbl : UCharTbl.Char.t = read_data  "age"
+  let age_tbl : UCharTbl.Char.t Lazy.t = lazy (read_data  "age")
 
-  let age u = version_of_char (UCharTbl.Char.get age_tbl u)
+  let age u = version_of_char (UCharTbl.Char.get (Lazy.force age_tbl) u)
   let older v1 v2 =
     ( version_to_char v1 ) <= ( version_to_char v2 )
 
@@ -510,10 +510,10 @@ module Make (Config : ConfigInt.Type) : Type = struct
 
   (* Combined class *)
 
-  let combined_class_tbl : UCharTbl.Char.t =
-    read_data  "combined_class"
+  let combined_class_tbl : UCharTbl.Char.t Lazy.t =
+    lazy (read_data  "combined_class")
 
-  let combined_class u = Char.code (UCharTbl.Char.get combined_class_tbl u)
+  let combined_class u = Char.code (UCharTbl.Char.get (Lazy.force combined_class_tbl) u)
 
   (* Decomposition *)
 

--- a/Camomile/toolslib/colParser.mly
+++ b/Camomile/toolslib/colParser.mly
@@ -41,7 +41,7 @@ yoriyuki.y@gmail.com
 open CamomileLibrary
 
 let parse_error _ = failwith "Syntax error"
-let acset : AbsCe.aceset_info = Toolslib.Unidata.read_data "acset"
+let acset : AbsCe.aceset_info Lazy.t = lazy (Toolslib.Unidata.read_data "acset")
 
     %}
 
@@ -58,19 +58,19 @@ let acset : AbsCe.aceset_info = Toolslib.Unidata.read_data "acset"
   %%
 main :
   header rules EOF
-  {let ceset = acset.lowercase_first_tbl in
+  {let ceset = (Lazy.force acset).lowercase_first_tbl in
   let ace_info = AbsCe.create_ace_info ceset in
   let ace_info = $1 ace_info in
   {ace_info with ceset = $2 ace_info.AbsCe.ceset}}
 | rules EOF
-  {let ceset = acset.lowercase_first_tbl in
+  {let ceset = (Lazy.force acset).lowercase_first_tbl in
   let ace_info = AbsCe.create_ace_info ceset in
   {ace_info with ceset = $1 ace_info.ceset}}
 | header EOF
-    {let ceset = acset.lowercase_first_tbl in
+    {let ceset = (Lazy.force acset).lowercase_first_tbl in
     $1 (AbsCe.create_ace_info ceset)}
 | EOF
-    {AbsCe.create_ace_info acset.lowercase_first_tbl};
+    {AbsCe.create_ace_info (Lazy.force acset).lowercase_first_tbl};
 
   header :
     header_option header
@@ -103,10 +103,10 @@ main :
 	  env
 
       | [("caseFirst" | "casefirst"); ("off" | "lower")] ->
-	  let ceset = acset.lowercase_first_tbl in
+	  let ceset = (Lazy.force acset).lowercase_first_tbl in
 	  {env with ceset = ceset}
       | [("caseFirst" | "casefirst"); "upper"] ->
-	  let ceset = acset.uppercase_first_tbl in
+	  let ceset = (Lazy.force acset).uppercase_first_tbl in
 	  {env with ceset = ceset}
       | ["strength"; _] ->
 	  prerr_endline "Warning : strength option is not supported";


### PR DESCRIPTION
When compiling camomile using several cores it might fail with the following errors (with backtraces):
```
parse_allkeys Camomile/database/acset.mar,Camomile/database/allkeys.mar (exit 2)
(cd _build/default/Camomile && tools/parse_allkeys.exe database unidata/tr10/allkeys.txt)
Fatal error: exception Not_found
Raised at file "Camomile/internal/database.ml", line 50, characters 52-67
Called from file "Camomile/internal/unidata.ml" (inlined), line 187, characters 4-48
Called from file "Camomile/public/uCharInfo.ml", line 443, characters 34-50
Called from file "Camomile/toolslib/absCe.ml", line 40, characters 14-44
parse_specialcasing Camomile/database/special_casing.mar (exit 2)
(cd _build/default/Camomile && tools/parse_specialcasing.exe database unidata/SpecialCasing.txt)
Fatal error: exception Not_found
Raised at file "Camomile/internal/database.ml", line 50, characters 52-67
Called from file "Camomile/internal/unidata.ml" (inlined), line 187, characters 4-48
Called from file "Camomile/public/uCharInfo.ml", line 443, characters 34-50
Called from file "Camomile/tools/parse_specialcasing.ml", line 40, characters 19-49
```
This PR fixes the issue. One thing I don't understand is how the call to `read_data "acset"` in `ColParser` didn't make everything fail every time since it is included in the `toolslib` library and this library is used to create `acset.mar` itself..

Anyway, I think avoiding side-effects on toplevel (even inside functors) is a good practice in any case.

Related to https://github.com/ocaml/opam-repository/pull/13980