### PR TITLE
Add (mode fallback) to installConfig.ml rule

### DIFF
--- a/Camomile/dune
+++ b/Camomile/dune
@@ -1,6 +1,9 @@
 ;; Default config, overridden by the configure.ml script
-(rule (with-stdout-to installConfig.ml
-       (echo "let share_dir = \"/usr/share/camomile\"")))
+(rule
+ (targets installConfig.ml)
+ (mode fallback)
+ (action (with-stdout-to %{targets}
+          (echo "let share_dir = \"/usr/share/camomile\""))))
 
 (library
  (name camomileLibrary)


### PR DESCRIPTION
To make the behaviour explicit when the `installConfig.ml` exist in the source tree because `configure.ml` generated it. Currently, we get the following warning:

```
$ dune build -p camomile
File "Camomile/dune", line 2, characters 0-96:
2 | (rule (with-stdout-to installConfig.ml
3 |        (echo "let share_dir = \"/usr/share/camomile\"")))
Warning: File installConfig.ml is both generated by a rule and present in the source tree.
As a result, the rule is currently ignored, however this will become an error in the future.
To keep the current behavior and get rid of this warning, add a field (fallback) to the rule.
```