### PR TITLE
Build iana executable

### DIFF
--- a/Camomile/tools/dune
+++ b/Camomile/tools/dune
@@ -11,8 +11,13 @@
         parse_age
         camomilestringprep)
  (flags -I Camomile :standard)
- (modules :standard \ camomilelocaledef camomilelocaledef_lexer)
+ (modules :standard \ camomilelocaledef camomilelocaledef_lexer iana)
  (libraries toolslib))
+
+(executable
+ (name iana)
+ (modules iana)
+ (libraries camomile str))
 
 (executable
  (name camomilelocaledef)

--- a/Camomile/tools/iana.ml
+++ b/Camomile/tools/iana.ml
@@ -32,10 +32,7 @@
 (* You can contact the authour by sending email to *)
 (* yoriyuki.y@gmail.com *)
 
-
-#load "bigarray.cma";;
-#load "camomile.cma";;
-#load "str.cma";;
+open CamomileLibraryDefault.Camomile
 
 let name_pat = Str.regexp "Name:[ \t]+\\([^ \t]+\\)"
 let alias_pat = Str.regexp "Alias:[ \t]+\\([^ \t]+\\)"


### PR DESCRIPTION
Previously, this module was simply ignored. It's now fixed and builds as
an executable.