### PR TITLE
Camomile/locales/eo.txt: Fix license by importing data from ICU

### DIFF
--- a/Camomile/locales/eo.txt
+++ b/Camomile/locales/eo.txt
@@ -1,34 +1,232 @@
-// ***************************************************************************
-// *                                                                         *
-// * COPYRIGHT:                                                              *
-// *   Copyright (C) 1997-2002, International Business Machines              *
-// * Licensed Material - Program-Property of IBM - All Rights Reserved.      *
-// * US Government Users Restricted Rights - Use, duplication, or disclosure *
-// * restricted by GSA ADP Schedule Contract with IBM Corp.                  *
-// *                                                                         *
-// ***************************************************************************
-// Feedback to : schererm@us.ibm.com
+// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
 
 eo {
     Version { "2.0" } 
-    Countries { 
-        AT { "A\u016dstrujo" }
-        BE { "Belgujo" }
-        CA { "Kanado" }
-        CH { "Svisujo" }
-        DE { "Germanujo" }
-        DK { "Danujo" }
-        ES { "Hispanujo" }
-        FI { "Finnlando" }
-        GR { "Grekujo" }
-        IT { "Italujo" }
-        JP { "Japanujo" }
-        NL { "Nederlando" }
-        NO { "Norvego" }
-        PT { "Portugalujo" }
-        SE { "Svedujo" }
-        TR { "Turkujo" }
-        US { "Usono" }
+    Countries{
+        001{"Mondo"}
+        AD{"Andoro"}
+        AE{"Unuiĝintaj Arabaj Emirlandoj"}
+        AF{"Afganujo"}
+        AG{"Antigvo-Barbudo"}
+        AI{"Angvilo"}
+        AL{"Albanujo"}
+        AM{"Armenujo"}
+        AO{"Angolo"}
+        AQ{"Antarkto"}
+        AR{"Argentino"}
+        AT{"Aŭstrujo"}
+        AU{"Aŭstralio"}
+        AW{"Arubo"}
+        AZ{"Azerbajĝano"}
+        BA{"Bosnio-Hercegovino"}
+        BB{"Barbado"}
+        BD{"Bangladeŝo"}
+        BE{"Belgujo"}
+        BF{"Burkino"}
+        BG{"Bulgarujo"}
+        BH{"Barejno"}
+        BI{"Burundo"}
+        BJ{"Benino"}
+        BM{"Bermudoj"}
+        BN{"Brunejo"}
+        BO{"Bolivio"}
+        BR{"Brazilo"}
+        BS{"Bahamoj"}
+        BT{"Butano"}
+        BW{"Bocvano"}
+        BY{"Belorusujo"}
+        BZ{"Belizo"}
+        CA{"Kanado"}
+        CF{"Centr-Afrika Respubliko"}
+        CG{"Kongolo"}
+        CH{"Svisujo"}
+        CI{"Ebur-Bordo"}
+        CK{"Kukinsuloj"}
+        CL{"Ĉilio"}
+        CM{"Kameruno"}
+        CN{"Ĉinujo"}
+        CO{"Kolombio"}
+        CR{"Kostariko"}
+        CU{"Kubo"}
+        CV{"Kabo-Verdo"}
+        CY{"Kipro"}
+        CZ{"Ĉeĥujo"}
+        DE{"Germanujo"}
+        DJ{"Ĝibutio"}
+        DK{"Danujo"}
+        DM{"Dominiko"}
+        DO{"Domingo"}
+        DZ{"Alĝerio"}
+        EC{"Ekvadoro"}
+        EE{"Estonujo"}
+        EG{"Egipto"}
+        EH{"Okcidenta Saharo"}
+        ER{"Eritreo"}
+        ES{"Hispanujo"}
+        ET{"Etiopujo"}
+        FI{"Finnlando"}
+        FJ{"Fiĝoj"}
+        FM{"Mikronezio"}
+        FO{"Ferooj"}
+        FR{"Francujo"}
+        GA{"Gabono"}
+        GB{"Unuiĝinta Reĝlando"}
+        GD{"Grenado"}
+        GE{"Kartvelujo"}
+        GF{"Franca Gviano"}
+        GH{"Ganao"}
+        GI{"Ĝibraltaro"}
+        GL{"Gronlando"}
+        GM{"Gambio"}
+        GN{"Gvineo"}
+        GP{"Gvadelupo"}
+        GQ{"Ekvatora Gvineo"}
+        GR{"Grekujo"}
+        GS{"Sud-Georgio kaj Sud-Sandviĉinsuloj"}
+        GT{"Gvatemalo"}
+        GU{"Gvamo"}
+        GW{"Gvineo-Bisaŭo"}
+        GY{"Gujano"}
+        HM{"Herda kaj Makdonaldaj Insuloj"}
+        HN{"Honduro"}
+        HR{"Kroatujo"}
+        HT{"Haitio"}
+        HU{"Hungarujo"}
+        ID{"Indonezio"}
+        IE{"Irlando"}
+        IL{"Israelo"}
+        IN{"Hindujo"}
+        IO{"Brita Hindoceana Teritorio"}
+        IQ{"Irako"}
+        IR{"Irano"}
+        IS{"Islando"}
+        IT{"Italujo"}
+        JM{"Jamajko"}
+        JO{"Jordanio"}
+        JP{"Japanujo"}
+        KE{"Kenjo"}
+        KG{"Kirgizistano"}
+        KH{"Kamboĝo"}
+        KI{"Kiribato"}
+        KM{"Komoroj"}
+        KN{"Sent-Kristofo kaj Neviso"}
+        KP{"Nord-Koreo"}
+        KR{"Sud-Koreo"}
+        KW{"Kuvajto"}
+        KY{"Kejmanoj"}
+        KZ{"Kazaĥstano"}
+        LA{"Laoso"}
+        LB{"Libano"}
+        LC{"Sent-Lucio"}
+        LI{"Liĥtenŝtejno"}
+        LK{"Sri-Lanko"}
+        LR{"Liberio"}
+        LS{"Lesoto"}
+        LT{"Litovujo"}
+        LU{"Luksemburgo"}
+        LV{"Latvujo"}
+        LY{"Libio"}
+        MA{"Maroko"}
+        MC{"Monako"}
+        MD{"Moldavujo"}
+        MG{"Madagaskaro"}
+        MH{"Marŝaloj"}
+        ML{"Malio"}
+        MM{"Mjanmao"}
+        MN{"Mongolujo"}
+        MP{"Nord-Marianoj"}
+        MQ{"Martiniko"}
+        MR{"Maŭritanujo"}
+        MT{"Malto"}
+        MU{"Maŭricio"}
+        MV{"Maldivoj"}
+        MW{"Malavio"}
+        MX{"Meksiko"}
+        MY{"Malajzio"}
+        MZ{"Mozambiko"}
+        NA{"Namibio"}
+        NC{"Nov-Kaledonio"}
+        NE{"Niĝero"}
+        NF{"Norfolkinsulo"}
+        NG{"Niĝerio"}
+        NI{"Nikaragvo"}
+        NL{"Nederlando"}
+        NO{"Norvegujo"}
+        NP{"Nepalo"}
+        NR{"Nauro"}
+        NU{"Niuo"}
+        NZ{"Nov-Zelando"}
+        OM{"Omano"}
+        PA{"Panamo"}
+        PE{"Peruo"}
+        PF{"Franca Polinezio"}
+        PG{"Papuo-Nov-Gvineo"}
+        PH{"Filipinoj"}
+        PK{"Pakistano"}
+        PL{"Pollando"}
+        PM{"Sent-Piero kaj Mikelono"}
+        PN{"Pitkarna Insulo"}
+        PR{"Puerto-Riko"}
+        PT{"Portugalujo"}
+        PW{"Belaŭo"}
+        PY{"Paragvajo"}
+        QA{"Kataro"}
+        RE{"Reunio"}
+        RO{"Rumanujo"}
+        RU{"Rusujo"}
+        RW{"Ruando"}
+        SA{"Saŭda Arabujo"}
+        SB{"Salomonoj"}
+        SC{"Sejŝeloj"}
+        SD{"Sudano"}
+        SE{"Svedujo"}
+        SG{"Singapuro"}
+        SH{"Sent-Heleno"}
+        SI{"Slovenujo"}
+        SJ{"Svalbardo kaj Jan-Majen-insulo"}
+        SK{"Slovakujo"}
+        SL{"Siera-Leono"}
+        SM{"San-Marino"}
+        SN{"Senegalo"}
+        SO{"Somalujo"}
+        SR{"Surinamo"}
+        ST{"Sao-Tomeo kaj Principeo"}
+        SV{"Salvadoro"}
+        SY{"Sirio"}
+        SZ{"Svazilando"}
+        TD{"Ĉado"}
+        TG{"Togolo"}
+        TH{"Tajlando"}
+        TJ{"Taĝikujo"}
+        TM{"Turkmenujo"}
+        TN{"Tunizio"}
+        TO{"Tongo"}
+        TR{"Turkujo"}
+        TT{"Trinidado kaj Tobago"}
+        TV{"Tuvalo"}
+        TW{"Tajvano"}
+        TZ{"Tanzanio"}
+        UA{"Ukrajno"}
+        UG{"Ugando"}
+        UM{"Usonaj malgrandaj insuloj"}
+        US{"Usono"}
+        UY{"Urugvajo"}
+        UZ{"Uzbekujo"}
+        VA{"Vatikano"}
+        VC{"Sent-Vincento kaj la Grenadinoj"}
+        VE{"Venezuelo"}
+        VG{"Britaj Virgulininsuloj"}
+        VI{"Usonaj Virgulininsuloj"}
+        VN{"Vjetnamo"}
+        VU{"Vanuatuo"}
+        WF{"Valiso kaj Futuno"}
+        WS{"Samoo"}
+        YE{"Jemeno"}
+        YT{"Majoto"}
+        ZA{"Sud-Afriko"}
+        ZM{"Zambio"}
+        ZW{"Zimbabvo"}
     }
     DateTimePatterns { 
         "H'-a horo kaj 'm z",
@@ -71,21 +269,159 @@ eo {
         "aK",
         "pK",
     }
-    Languages { 
-        da { "dana" }
-        de { "germana" }
-        el { "greka" }
-        en { "angla" }
-        eo { "esperanto" }
-        es { "hispana" }
-        fi { "finna" }
-        it { "itala" }
-        ja { "japana" }
-        nl { "nederlanda" }
-        no { "norvega" }
-        pt { "portugala" }
-        sv { "sveda" }
-        tr { "turka" }
+    Languages{
+        aa{"afara"}
+        ab{"abĥaza"}
+        af{"afrikansa"}
+        am{"amhara"}
+        ar{"araba"}
+        as{"asama"}
+        ay{"ajmara"}
+        az{"azerbajĝana"}
+        ba{"baŝkira"}
+        be{"belorusa"}
+        bg{"bulgara"}
+        bi{"bislamo"}
+        bn{"bengala"}
+        bo{"tibeta"}
+        br{"bretona"}
+        bs{"bosnia"}
+        ca{"kataluna"}
+        co{"korsika"}
+        cs{"ĉeĥa"}
+        cy{"kimra"}
+        da{"dana"}
+        de{"germana"}
+        dv{"mahla"}
+        dz{"dzonko"}
+        efi{"ibibioefika"}
+        el{"greka"}
+        en{"angla"}
+        eo{"esperanto"}
+        es{"hispana"}
+        et{"estona"}
+        eu{"eŭska"}
+        fa{"persa"}
+        fi{"finna"}
+        fil{"filipina"}
+        fj{"fiĝia"}
+        fo{"feroa"}
+        fr{"franca"}
+        fy{"frisa"}
+        ga{"irlanda"}
+        gd{"gaela"}
+        gl{"galega"}
+        gn{"gvarania"}
+        gu{"guĝarata"}
+        ha{"haŭsa"}
+        haw{"havaja"}
+        he{"hebrea"}
+        hi{"hinda"}
+        hr{"kroata"}
+        ht{"haitia kreola"}
+        hu{"hungara"}
+        hy{"armena"}
+        ia{"interlingvao"}
+        id{"indonezia"}
+        ie{"okcidentalo"}
+        ik{"eskima"}
+        is{"islanda"}
+        it{"itala"}
+        iu{"inuita"}
+        ja{"japana"}
+        jv{"java"}
+        ka{"kartvela"}
+        kk{"kazaĥa"}
+        kl{"gronlanda"}
+        km{"kmera"}
+        kn{"kanara"}
+        ko{"korea"}
+        ks{"kaŝmira"}
+        ku{"kurda"}
+        ky{"kirgiza"}
+        la{"latino"}
+        lb{"luksemburga"}
+        ln{"lingala"}
+        lo{"laŭa"}
+        lt{"litova"}
+        lv{"latva"}
+        mg{"malagasa"}
+        mi{"maoria"}
+        mk{"makedona"}
+        ml{"malajalama"}
+        mn{"mongola"}
+        mr{"marata"}
+        ms{"malaja"}
+        mt{"malta"}
+        my{"birma"}
+        na{"naura"}
+        nb{"dannorvega"}
+        ne{"nepala"}
+        nl{"nederlanda"}
+        nn{"novnorvega"}
+        no{"norvega"}
+        oc{"okcitana"}
+        om{"oroma"}
+        or{"orijo"}
+        pa{"panĝaba"}
+        pl{"pola"}
+        ps{"paŝtoa"}
+        pt{"portugala"}
+        pt_BR{"brazilportugala"}
+        pt_PT{"eŭropportugala"}
+        qu{"keĉua"}
+        rm{"romanĉa"}
+        rn{"burunda"}
+        ro{"rumana"}
+        ru{"rusa"}
+        rw{"ruanda"}
+        sa{"sanskrito"}
+        sd{"sinda"}
+        sg{"sangoa"}
+        sh{"serbo-Kroata"}
+        si{"sinhala"}
+        sk{"slovaka"}
+        sl{"slovena"}
+        sm{"samoa"}
+        sn{"ŝona"}
+        so{"somala"}
+        sq{"albana"}
+        sr{"serba"}
+        ss{"svazia"}
+        st{"sota"}
+        su{"sunda"}
+        sv{"sveda"}
+        sw{"svahila"}
+        ta{"tamila"}
+        te{"telugua"}
+        tg{"taĝika"}
+        th{"taja"}
+        ti{"tigraja"}
+        tk{"turkmena"}
+        tl{"tagaloga"}
+        tlh{"klingona"}
+        tn{"cvana"}
+        to{"tongaa"}
+        tr{"turka"}
+        ts{"conga"}
+        tt{"tatara"}
+        ug{"ujgura"}
+        uk{"ukraina"}
+        und{"nekonata lingvo"}
+        ur{"urduo"}
+        uz{"uzbeka"}
+        vi{"vjetnama"}
+        vo{"volapuko"}
+        wo{"volofa"}
+        xh{"ksosa"}
+        yi{"jida"}
+        yo{"joruba"}
+        za{"ĝuanga"}
+        zh{"ĉina"}
+        zh_Hans{"ĉina simpligita"}
+        zh_Hant{"ĉina tradicia"}
+        zu{"zulua"}
+        zxx{"nelingvaĵo"}
     }
     //LocaleID { "07e0" }
 //    LocaleString { "eo" }
@@ -140,26 +476,41 @@ eo {
     // Rule Based Number Format Support
     //------------------------------------------------------------
 
-// data from 'Esperanto-programita 1' courtesy of Markus Scherer
-
-    SpelloutRules {
-        "-x: minus >>;\n"
-        "x.x: << komo >>;\n"
-        "nulo; unu; du; tri; kvar; kvin; ses; sep; ok; na\u016d;\n"
-        "10: dek[ >>];\n"
-        "20: <<dek[ >>];\n"
-        "100: cent[ >>];\n"
-        "200: <<cent[ >>];\n"
-        "1000: mil[ >>];\n"
-        "2000: <<mil[ >>];\n"
-        "10000: dekmil[ >>];\n"
-        "11000>: << mil[ >>];\n"
-        "1,000,000: miliono[ >>];\n"
-        "2,000,000: << milionoj[ >>];\n"
-        "1,000,000,000: miliardo[ >>];\n"
-        "2,000,000,000: << miliardoj[ >>];\n"
-        "1,000,000,000,000: biliono[ >>];\n"
-        "2,000,000,000,000: << bilionoj[ >>];\n"
-        "1,000,000,000,000,000: =#,##0=;\n"
+    SpelloutRules{
+        "%spellout-numbering-year:",
+        "x.x: =0.0=;",
+        "0: =%spellout-numbering=;",
+        "%spellout-numbering:",
+        "0: =%spellout-cardinal=;",
+        "%spellout-cardinal:",
+        "-x: minus >>;",
+        "x.x: << komo >>;",
+        "0: nulo;",
+        "1: unu;",
+        "2: du;",
+        "3: tri;",
+        "4: kvar;",
+        "5: kvin;",
+        "6: ses;",
+        "7: sep;",
+        "8: ok;",
+        "9: na\u016D;",
+        "10: dek[ >>];",
+        "20: <<dek[ >>];",
+        "100: cent[ >>];",
+        "200: <<cent[ >>];",
+        "1000: mil[ >>];",
+        "2000: << mil[ >>];",
+        "1000000: miliono[ >>];",
+        "2000000: << milionoj[ >>];",
+        "1000000000: miliardo[ >>];",
+        "2000000000: << miliardoj[ >>];",
+        "1000000000000: biliono[ >>];",
+        "2000000000000: << bilionoj[ >>];",
+        "1000000000000000: biliardo[ >>];",
+        "2000000000000000: << biliardoj[ >>];",
+        "1000000000000000000: =#,##0=;",
+        "%spellout-ordinal:",
+        "0: =%spellout-cardinal=a;",
     }
 }


### PR DESCRIPTION
The license for this particular (Esperanto) file is non-free.
Possibly it is supposed to be overridden by the "license.html" file in
the current directory, but our tooling can't read HTML files.

We can fix this by importing the same data from the newer Unicode ICU
project files, as these are distributed under a free license.  This
also gives us slightly increased functionality.

See also:

https://lists.fedoraproject.org/archives/list/legal@lists.fedoraproject.org/thread/EP453A4JSXM2DKIBLPYBKLID47OCKCPW/

Signed-off-by: Richard W.M. Jones <rjones@redhat.com>