### PR TITLE
Add support for OCaml 5.00

### DIFF
--- a/Camomile/dune
+++ b/Camomile/dune
@@ -9,7 +9,7 @@
  (name camomileLibrary)
  (public_name camomile.library)
  (wrapped true)
- (libraries bigarray camomileDefaultConfig camlp-streams)
+ (libraries bigarray camomileDefaultConfig camlp-streams stdlib-shims)
  (modules
   :standard \ camomileDefaultConfig
   camomile_do_not_use

--- a/Camomile/dune
+++ b/Camomile/dune
@@ -9,7 +9,7 @@
  (name camomileLibrary)
  (public_name camomile.library)
  (wrapped true)
- (libraries bigarray camomileDefaultConfig camlp-streams stdlib-shims)
+ (libraries bigarray-compat camomileDefaultConfig camlp-streams stdlib-shims)
  (modules
   :standard \ camomileDefaultConfig
   camomile_do_not_use

--- a/Camomile/dune
+++ b/Camomile/dune
@@ -9,7 +9,7 @@
  (name camomileLibrary)
  (public_name camomile.library)
  (wrapped true)
- (libraries bigarray camomileDefaultConfig)
+ (libraries bigarray camomileDefaultConfig camlp-streams)
  (modules
   :standard \ camomileDefaultConfig
   camomile_do_not_use

--- a/Camomile/internal/byte_labeled_dag.ml
+++ b/Camomile/internal/byte_labeled_dag.ml
@@ -87,7 +87,7 @@ let make_bytes def vs =
           branch.(Char.code c') <- Some node;
           scan d c leaf branch rest
   in
-  let comp (s1, _) (s2, _) = Pervasives.compare s1 s2 in
+  let comp (s1, _) (s2, _) = Stdlib.compare s1 s2 in
   let vs = List.sort comp vs in
   match vs with
     (_, _) :: _ ->

--- a/Camomile/internal/unidata.ml
+++ b/Camomile/internal/unidata.ml
@@ -299,13 +299,6 @@ module Make (Config : ConfigInt.Type) = struct
     | `Buhid
     | `Tagbanwa ]
 
-  (* little hack to maintain 4.02.3 compat with warnings *)
-  module String = struct
-    [@@@ocaml.warning "-3-32"]
-    let lowercase_ascii = StringLabels.lowercase
-    include String
-  end
-
   let script_of_name name =
     match String.lowercase_ascii name with
     | "common" -> `Common

--- a/Camomile/public/charEncoding.ml
+++ b/Camomile/public/charEncoding.ml
@@ -131,12 +131,12 @@ module type Interface = sig
       {!OOChannel.obj_output_channel} which
       receives Unicode characters and outputs them to [outchan] using
       the encoding [enc]. *)
-  class out_channel : t -> Pervasives.out_channel -> [UChar.t] obj_output_channel
+  class out_channel : t -> Stdlib.out_channel -> [UChar.t] obj_output_channel
 
   (** [new in_channel enc inchan] creates the intput channel object
       {!OOChannel.obj_input_channel} which
       reads bytes from [inchan] and converts them to Unicode characters. *)
-  class in_channel : t -> Pervasives.in_channel -> [UChar.t] obj_input_channel
+  class in_channel : t -> Stdlib.in_channel -> [UChar.t] obj_input_channel
 
   (** [ustream_of enc chars] converts the byte stream [chars]
       to the Unicode character stream by the encoding [enc]. *)

--- a/Camomile/public/charEncoding.mli
+++ b/Camomile/public/charEncoding.mli
@@ -130,12 +130,12 @@ module type Interface = sig
       {!OOChannel.obj_output_channel} which
       receives Unicode characters and outputs them to [outchan] using
       the encoding [enc]. *)
-  class out_channel : t -> Pervasives.out_channel -> [UChar.t] obj_output_channel
+  class out_channel : t -> Stdlib.out_channel -> [UChar.t] obj_output_channel
 
   (** [new in_channel enc inchan] creates the intput channel object 
       {!OOChannel.obj_input_channel} which
       reads bytes from [inchan] and converts them to Unicode characters. *)
-  class in_channel : t -> Pervasives.in_channel -> [UChar.t] obj_input_channel
+  class in_channel : t -> Stdlib.in_channel -> [UChar.t] obj_input_channel
 
   (** [ustream_of enc chars] converts the byte stream [chars] 
       to the Unicode character stream by the encoding [enc]. *)

--- a/Camomile/public/oOChannel.mli
+++ b/Camomile/public/oOChannel.mli
@@ -113,7 +113,7 @@ class char_obj_output_channel_of : char_output_channel ->
   [char] obj_output_channel
 
 (** Convert an OCaml input channel to an OO-based character input channel *)
-class of_in_channel : Pervasives.in_channel -> char_input_channel
+class of_in_channel : Stdlib.in_channel -> char_input_channel
 
 (** Convert an OCaml output channel to an OO-based character output channel *)
-class of_out_channel : Pervasives.out_channel -> char_output_channel
+class of_out_channel : Stdlib.out_channel -> char_output_channel

--- a/Camomile/public/uCS4.ml
+++ b/Camomile/public/uCS4.ml
@@ -140,5 +140,5 @@ end
 
 let compare (a:t) (b:t) =
   match Array1.dim a - Array1.dim b with
-    0 -> Pervasives.compare a b
+    0 -> Stdlib.compare a b
   | sgn -> sgn

--- a/Camomile/public/uCS4.ml
+++ b/Camomile/public/uCS4.ml
@@ -36,7 +36,7 @@
 (* yoriyuki.y@gmail.com *)
 
 
-open Bigarray
+open Bigarray_compat
 
 (* UCS4 encoded string. the type is bigarray of 32-bit integers. *)
 type t = (int32, int32_elt, c_layout) Array1.t

--- a/Camomile/public/uCS4.mli
+++ b/Camomile/public/uCS4.mli
@@ -36,7 +36,10 @@
 (* yoriyuki.y@gmail.com *)
 
 type t =
-  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
+  (int32,
+   Bigarray_compat.int32_elt,
+   Bigarray_compat.c_layout)
+  Bigarray_compat.Array1.t
 
 exception Malformed_code
 

--- a/Camomile/public/uCol.ml
+++ b/Camomile/public/uCol.ml
@@ -52,14 +52,14 @@ sig
       If [prec] is omitted, the maximum possible strength is used.
       If [variable] is omitted, the default of the locale
       (usually [`Shifted]) is used.
-      The meaning of the returned value is similar to Pervasives.compare *)
+      The meaning of the returned value is similar to Stdlib.compare *)
   val compare :
     ?locale:string -> ?prec:precision -> ?variable:variable_option ->
     text -> text -> int
 
   (** Binary comparison of sort_key gives the same result as [compare].
       i.e.
-      [compare t1 t2 = Pervasives.compare (sort_key t1) (sort_key t2)]
+      [compare t1 t2 = Stdlib.compare (sort_key t1) (sort_key t2)]
       If the same texts are repeatedly compared,
       pre-computation of sort_key gives better performance. *)
   val sort_key :
@@ -731,7 +731,7 @@ module Make (Config : ConfigInt.Type) (Text : UnicodeString.Type) = struct
       | _ ->
         let key1 = key_of_inc prec col_info x1 in
         let key2 = key_of_inc prec col_info x2 in
-        Pervasives.compare key1 key2
+        Stdlib.compare key1 key2
 
   let compare ?locale ?prec ?variable t1 t2 =
     let col_info =
@@ -782,7 +782,7 @@ module Make (Config : ConfigInt.Type) (Text : UnicodeString.Type) = struct
       | _ ->
         let key = key_of_inc prec col_info x in
         (*      Printf.printf "key_of_inc %s\n" (String.escaped key);*)
-        Pervasives.compare k key
+        Stdlib.compare k key
 
   let compare_with_key ?locale ?prec ?variable k t =
     let col_info =

--- a/Camomile/public/uTF16.ml
+++ b/Camomile/public/uTF16.ml
@@ -34,7 +34,7 @@
 (* You can contact the authour by sending email to *)
 (* yoriyuki.y@gmail.com *)
 
-open Bigarray
+open Bigarray_compat
 
 exception Out_of_range
 

--- a/Camomile/public/uTF16.mli
+++ b/Camomile/public/uTF16.mli
@@ -37,7 +37,10 @@
     0xfffe, 0xffff.
     Bigarray.cma or Bigarray.cmxa must be linked when this module is used. *)
 type t = 
-  (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+  (int,
+   Bigarray_compat.int16_unsigned_elt,
+   Bigarray_compat.c_layout)
+  Bigarray_compat.Array1.t
 
 exception Malformed_code
 

--- a/Camomile/public/uTF8.ml
+++ b/Camomile/public/uTF8.ml
@@ -194,7 +194,7 @@ let rec iter_aux proc s i =
 
 let iter proc s = iter_aux proc s 0
 
-let compare s1 s2 = Pervasives.compare s1 s2
+let compare s1 s2 = Stdlib.compare s1 s2
 
 exception Malformed_code
 

--- a/Camomile/tools/dune
+++ b/Camomile/tools/dune
@@ -12,7 +12,7 @@
         camomilestringprep)
  (flags -I Camomile :standard)
  (modules :standard \ camomilelocaledef camomilelocaledef_lexer iana)
- (libraries toolslib camomile camomile.library))
+ (libraries toolslib camomile camomile.library camlp-streams))
 
 (executable
  (name iana)
@@ -21,6 +21,6 @@
 
 (executable
  (name camomilelocaledef)
- (libraries toolslib camomile.library)
+ (libraries toolslib camomile.library camlp-streams)
  (flags -I Camomile :standard)
  (modules camomilelocaledef camomilelocaledef_lexer))

--- a/Camomile/tools/parse_specialcasing.ml
+++ b/Camomile/tools/parse_specialcasing.ml
@@ -49,13 +49,6 @@ let us_of_codes codes = List.map uchar_of_code codes
 let not_pat = Str.regexp "not_\\(.*\\)"
 let locale_pat = Str.regexp "\\(..\\)\\(_\\(..\\)\\)?\\(_\\(.+\\)\\)?"
 
-(* little hack to maintain 4.02.3 compat with warnings *)
-module String = struct
-  [@@@ocaml.warning "-3-32"]
-  let lowercase_ascii = StringLabels.lowercase
-  include String
-end
-
 let rec parse_condition condition =
   let s = String.lowercase_ascii condition in
   match s with

--- a/Camomile/toolslib/absCe.ml
+++ b/Camomile/toolslib/absCe.ml
@@ -49,7 +49,7 @@ type elt =
   | `FirstImplicit
   | `FirstTrailing ]
 
-module Elt = struct type t = elt let compare = Pervasives.compare end
+module Elt = struct type t = elt let compare = Stdlib.compare end
 module EltMap = Map.Make (Elt)
 
 type ce = AbsOrd.point * AbsOrd.point * AbsOrd.point

--- a/Camomile/toolslib/dune
+++ b/Camomile/toolslib/dune
@@ -4,7 +4,7 @@
  (name toolslib)
  (wrapped false)
  (flags -I Camomile :standard)
- (libraries camomile camomile.library bigarray str stdlib-shims))
+ (libraries camomile camomile.library bigarray-compat str stdlib-shims))
 
 (ocamllex  colLexer)
 (ocamlyacc colParser)

--- a/Camomile/toolslib/dune
+++ b/Camomile/toolslib/dune
@@ -4,7 +4,7 @@
  (name toolslib)
  (wrapped false)
  (flags -I Camomile :standard)
- (libraries camomile camomile.library bigarray str))
+ (libraries camomile camomile.library bigarray str stdlib-shims))
 
 (ocamllex  colLexer)
 (ocamlyacc colParser)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ test:
 clean:
 	dune clean
 
-# unfortunately we cannot turn on warnings in development because of 4.02.3
 all-supported-ocaml-versions:
 	dune build --workspace dune-workspace.dev
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ OCaml packages. See [LICENSE.md](LICENSE.md)
 
 ## Installation
 
-To build and install Camomile, you need [OCaml](https://ocaml.org) >= 4.02.3 [dune](https://dune.build) >= 1.0.0
+To build and install Camomile, you need [OCaml](https://ocaml.org) >= 4.03 [dune](https://dune.build) >= 1.11
 
 To build the library, on the top directory do
 ```sh

--- a/camomile-test/tester/test_caseMap.ml
+++ b/camomile-test/tester/test_caseMap.ml
@@ -7,13 +7,6 @@ open CamomileLibraryTest.Camomile
 
 module UTF8Casing = CaseMap.Make (UTF8)
 
-(* little hack to maintain 4.02.3 compat with warnings *)
-module String = struct
-  [@@@ocaml.warning "-3-32"]
-  let lowercase_ascii = StringLabels.lowercase
-  include String
-end
-
 let _ = random_test
     ~desc:"ASCII"
     ~log:"caseMap_ASCII"

--- a/camomile-test/tester/uCS4_test.ml
+++ b/camomile-test/tester/uCS4_test.ml
@@ -2,7 +2,7 @@
 open CamomileLibraryTest.Camomile
 open UPervasives
 open Blender
-open Bigarray
+open Bigarray_compat
 
 module UCS4Test = UStorageTest.Make (UCS4)
 

--- a/camomile-test/tester/uTF16_test.ml
+++ b/camomile-test/tester/uTF16_test.ml
@@ -2,7 +2,7 @@
 open CamomileLibraryTest.Camomile
 open UPervasives
 open Blender
-open Bigarray
+open Bigarray_compat
 
 module UTF16Conv = CharEncoding.Make (UTF16)
 module UTF16Test = UStorageTest.Make (UTF16)
@@ -18,9 +18,9 @@ let char_gen _ =
 let _ = UTF16Test.test ~desc:"UTF16 test" ~log:"base_utf16" ~char_gen ()
 
 let string_of_int16array a =
-  let s = Bytes.create (2 + 2 * Bigarray.Array1.dim a) in
+  let s = Bytes.create (2 + 2 * Bigarray_compat.Array1.dim a) in
   Bytes.set s 0 (Char.chr 0xfe); Bytes.set s 1 (Char.chr 0xff);
-  for i = 0 to Bigarray.Array1.dim a - 1 do
+  for i = 0 to Bigarray_compat.Array1.dim a - 1 do
     Bytes.set s (2 * i + 2) (Char.chr (a.{i} lsr 8));
     Bytes.set s (2 * i + 3) (Char.chr (a.{i} land 255))
   done;

--- a/camomile.opam
+++ b/camomile.opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "camlp-streams"
   "stdlib-shims"
+  "bigarray-compat"
 ]
 dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
 build: [

--- a/camomile.opam
+++ b/camomile.opam
@@ -14,7 +14,9 @@ doc: "https://yoriyuki.github.io/Camomile/"
 bug-reports: "https://github.com/yoriyuki/Camomile/issues"
 depends: [
   "dune" {>= "1.11"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03"}
+  "camlp-streams"
+  "stdlib-shims"
 ]
 dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
 build: [

--- a/dune-project
+++ b/dune-project
@@ -21,4 +21,5 @@ designed for Unicode Standard 3.2.")
   (dune (>= 1.11))
   (ocaml (>= 4.03))
   camlp-streams
-  stdlib-shims))
+  stdlib-shims
+  bigarray-compat))

--- a/dune-project
+++ b/dune-project
@@ -19,4 +19,6 @@ collation and locale-sensitive case mappings, and more. The library is currently
 designed for Unicode Standard 3.2.")
  (depends
   (dune (>= 1.11))
-  (ocaml (>= "4.02.3"))))
+  (ocaml (>= 4.03))
+  camlp-streams
+  stdlib-shims))

--- a/dune-workspace.dev
+++ b/dune-workspace.dev
@@ -1,5 +1,4 @@
 ;; This file is used by `make all-supported-ocaml-versions`
-(context ((switch 4.02.3)))
 (context ((switch 4.03.0)))
 (context ((switch 4.04.2)))
 (context ((switch 4.05.0)))


### PR DESCRIPTION
Patch from @anmonteiro

This removes support for OCaml 4.02 which I think given its age is fair enough.
If you don’t care about the OCaml < 4.08 you can also remove the dependencies to `stdlib-shims`